### PR TITLE
Fix typo in fullscreen preload

### DIFF
--- a/src/fullscreen-preload.cjs
+++ b/src/fullscreen-preload.cjs
@@ -4,7 +4,9 @@ console.log("[fullscreen-preload] loaded");
 
 contextBridge.exposeInMainWorld("fullscreen", {
   onContentUpdate: (callback) => {
-    console.log("[fullscreen-preload] received content:", content);
-    ipcRenderer.on("fullscreen-content", (_, content) => callback(content));
+    ipcRenderer.on("fullscreen-content", (_, content) => {
+      console.log("[fullscreen-preload] received content:", content);
+      callback(content);
+    });
   },
 });


### PR DESCRIPTION
## Summary
- log fullscreen content safely in fullscreen preload handler

## Testing
- `npm run build` *(fails: vite not found)*
- `node -e "require('./src/fullscreen-preload.cjs'); console.log('ok')"` *(fails: cannot find module 'electron')*

------
https://chatgpt.com/codex/tasks/task_e_683fe9e0dff4832ab1ac292d37f0cf89