### PR TITLE
Fix extraneous braces in fullscreen style

### DIFF
--- a/assets/fullscreen.html
+++ b/assets/fullscreen.html
@@ -34,13 +34,6 @@
         overflow-wrap: break-word;
         overflow: hidden;
       }
-
-
-
-
-                        }
-
-                              }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- clean up `assets/fullscreen.html` by removing stray closing braces after the `#content` style block

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845406bd78c832aa1045b45ceadd4e5