### PR TITLE
Improve presentation navigation

### DIFF
--- a/assets/fullscreen.html
+++ b/assets/fullscreen.html
@@ -46,6 +46,10 @@
           "<br>"
         );
       });
+
+      document.addEventListener("keydown", (e) => {
+        window.fullscreen.sendKeyDown(e.code);
+      });
     </script>
   </body>
 </html>

--- a/assets/fullscreen.html
+++ b/assets/fullscreen.html
@@ -4,21 +4,21 @@
     <meta charset="UTF-8" />
     <title>Fullscreen</title>
     <style>
-                              html,
-                              body {
-                                margin: 0;
-                                padding: 0;
-                                height: 100%;
-                                width: 100%;
-                                background: black;
-                                color: white;
-                                display: flex;
-                                align-items: center;
-                                justify-content: center;
-                                text-align: center;
-                                overflow: hidden;
-                              }
-                              #content {
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+        background: black;
+        color: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        overflow: hidden;
+      }
+      #content {
         display: flex;
         align-items: center;
         justify-content: center;

--- a/src/fullscreen-preload.cjs
+++ b/src/fullscreen-preload.cjs
@@ -9,4 +9,7 @@ contextBridge.exposeInMainWorld("fullscreen", {
       callback(content);
     });
   },
+  sendKeyDown: (code) => {
+    ipcRenderer.send("fullscreen-keydown", code);
+  },
 });

--- a/src/main.js
+++ b/src/main.js
@@ -118,6 +118,12 @@ ipcMain.handle("close-fullscreen", () => {
   if (fsWin && !fsWin.isDestroyed()) fsWin.close();
 });
 
+ipcMain.on("fullscreen-keydown", (e, code) => {
+  if (mainWin) {
+    mainWin.webContents.send("fullscreen-keydown", code);
+  }
+});
+
 ipcMain.handle("create-schedule", (e) => {
   const baseName = new Date().toLocaleDateString("pl-PL"); // "03.05.2025"
   let name = baseName;

--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -10,6 +10,11 @@ contextBridge.exposeInMainWorld("api", {
   setFullscreenContent: (text) =>
     ipcRenderer.invoke("set-fullscreen-content", text),
   onFullscreenClosed: (cb) => ipcRenderer.on("fullscreen-closed", cb),
+  onFullscreenKeyDown: (cb) => {
+    const listener = (_event, code) => cb(code);
+    ipcRenderer.on("fullscreen-keydown", listener);
+    return () => ipcRenderer.removeListener("fullscreen-keydown", listener);
+  },
   createSchedule: () => ipcRenderer.invoke("create-schedule"),
   getSchedules: () => ipcRenderer.invoke("get-schedules"),
   getScheduleSongs: (scheduleId) =>

--- a/src/renderer/DisplaySelector.jsx
+++ b/src/renderer/DisplaySelector.jsx
@@ -84,12 +84,10 @@ export default function DisplaySelector() {
   };
 
   useEffect(() => {
-    const handleKeyDown = async (event) => {
+    const handleAction = async (code) => {
       if (!windowOpened || !scheduleSongs.length) return;
 
-      if (event.code === "Space" || event.code === "ArrowRight") {
-        event.preventDefault();
-
+      if (code === "Space" || code === "ArrowRight") {
         const current = await window.api.getSong(
           scheduleSongs[currentSongIndex].song_id
         );
@@ -103,9 +101,7 @@ export default function DisplaySelector() {
           setCurrentVerseIndex(0);
           sendCurrent(nextSong, 0);
         }
-      } else if (event.code === "ArrowLeft") {
-        event.preventDefault();
-
+      } else if (code === "ArrowLeft") {
         if (currentVerseIndex > 0) {
           const prev = currentVerseIndex - 1;
           setCurrentVerseIndex(prev);
@@ -120,17 +116,30 @@ export default function DisplaySelector() {
           setCurrentVerseIndex(lastVerse);
           sendCurrent(prevSong, lastVerse);
         }
-      } else if (event.code === "ArrowUp") {
-        event.preventDefault();
+      } else if (code === "ArrowUp") {
         handleNextSong();
-      } else if (event.code === "ArrowDown") {
-        event.preventDefault();
+      } else if (code === "ArrowDown") {
         handlePreviousSong();
+      } else if (code === "Escape") {
+        setWindowOpened(false);
+        window.api.closeFullscreen();
       }
     };
 
+    const handleKeyDown = (event) => {
+      event.preventDefault();
+      handleAction(event.code);
+    };
+
+    const removeFs = window.api.onFullscreenKeyDown?.((code) => {
+      handleAction(code);
+    });
+
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      removeFs?.();
+    };
   }, [windowOpened, currentSongIndex, currentVerseIndex, scheduleSongs]);
 
   const handleNextSong = async () => {

--- a/src/renderer/components/Schedule.jsx
+++ b/src/renderer/components/Schedule.jsx
@@ -7,6 +7,7 @@ export const Schedule = ({
   scheduleSongs,
   setScheduleSongs,
   currentSongId,
+  onPreviewSong,
 }) => {
   const [songs, setSongs] = useState([]);
 
@@ -72,6 +73,7 @@ export const Schedule = ({
             className={`border-b border-gray-300 w-full cursor-pointer hover:bg-gray-100 transition-colors text-left flex items-center pr-2 ${
               s.song_id === currentSongId ? "bg-green-100" : ""
             }`}
+            onClick={() => onPreviewSong && onPreviewSong(s.song_id)}
           >
             <span className="border-r border-gray-300 py-1 px-3">
               {index + 1}.
@@ -80,7 +82,10 @@ export const Schedule = ({
             <div className="flex items-center gap-1">
               <button
                 disabled={index === 0}
-                onClick={() => swapSongs(index, index - 1)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  swapSongs(index, index - 1);
+                }}
                 className={`transition-colors h-6 w-6 flex justify-center items-center rounded ${
                   index === 0
                     ? "text-gray-300"
@@ -91,7 +96,10 @@ export const Schedule = ({
               </button>
               <button
                 disabled={index === scheduleSongs.length - 1}
-                onClick={() => swapSongs(index, index + 1)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  swapSongs(index, index + 1);
+                }}
                 className={`transition-colors h-6 w-6 flex justify-center items-center rounded ${
                   index === scheduleSongs.length - 1
                     ? "text-gray-300"
@@ -102,7 +110,10 @@ export const Schedule = ({
               </button>
               <button
                 className="hover:bg-green-200 transition-colors h-6 w-6 flex justify-center items-center rounded cursor-pointer text-gray-700"
-                onClick={() => handleRemove(s.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemove(s.id);
+                }}
               >
                 <IoClose size={20} />
               </button>

--- a/src/renderer/components/SongList.jsx
+++ b/src/renderer/components/SongList.jsx
@@ -6,6 +6,7 @@ export const SongList = ({
   setSelectedSongId,
   selectedSchedule,
   onSongAdded,
+  onPreview,
 }) => {
   const [songs, setSongs] = useState([]);
 
@@ -21,7 +22,10 @@ export const SongList = ({
         <li key={s.id}>
           <button
             className="border-b border-gray-300 w-full py-1 px-3 cursor-pointer hover:bg-gray-100 transition-colors text-left flex"
-            onClick={() => setSelectedSongId(s.id)}
+            onClick={() => {
+              setSelectedSongId(s.id);
+              if (onPreview) onPreview(s.id);
+            }}
           >
             <span className="flex-1">{s.title}</span>
             <button


### PR DESCRIPTION
## Summary
- update presentation mode to show current text on preview and fullscreen
- add keyboard navigation for verses and songs
- keep indexes when schedule updates during presentation

## Testing
- `npm run build` *(fails: ERR_ELECTRON_BUILDER_CANNOT_EXECUTE)*

------
https://chatgpt.com/codex/tasks/task_e_6845471e5be8832a8df18d178946a6f1