### PR TITLE
Add song editor

### DIFF
--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -25,4 +25,5 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.invoke("add-song-to-schedule", scheduleId, songId),
   swapSchedulePositions: (idA, idB) =>
     ipcRenderer.invoke("swap-schedule-positions", idA, idB),
+  saveSong: (song) => ipcRenderer.invoke("save-song", song),
 });

--- a/src/renderer/DisplaySelector.jsx
+++ b/src/renderer/DisplaySelector.jsx
@@ -157,6 +157,16 @@ export default function DisplaySelector() {
     };
 
     const handleKeyDown = (event) => {
+      const target = event.target;
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
       event.preventDefault();
       handleAction(event.code);
     };

--- a/src/renderer/DisplaySelector.jsx
+++ b/src/renderer/DisplaySelector.jsx
@@ -33,6 +33,7 @@ export default function DisplaySelector() {
   const [previewSong, setPreviewSong] = useState(null);
   const [previewVerseIndex, setPreviewVerseIndex] = useState(0);
   const [editorSongId, setEditorSongId] = useState(null);
+  const [previousTab, setPreviousTab] = useState("categories");
 
   useEffect(() => {
     window.api.getDisplays().then(async (list) => {
@@ -81,6 +82,12 @@ export default function DisplaySelector() {
     const data = await window.api.getSong(songId);
     setPreviewSong(data);
     setPreviewVerseIndex(0);
+  };
+
+  const openEditor = (songId = null) => {
+    setEditorSongId(songId);
+    setPreviousTab(selectedTab);
+    setSelectedTab("editor");
   };
 
   const handlePreviewNext = () => {
@@ -252,7 +259,11 @@ export default function DisplaySelector() {
     <div className="flex flex-1 flex-col">
       <div className="flex-1 flex overflow-hidden">
         {selectedTab === "editor" ? (
-          <SongEditor songId={editorSongId} setSongId={setEditorSongId} />
+          <SongEditor
+            songId={editorSongId}
+            setSongId={setEditorSongId}
+            onBack={() => setSelectedTab(previousTab)}
+          />
         ) : (
           <>
             <div className="flex-1 border-r border-gray-300">
@@ -277,10 +288,7 @@ export default function DisplaySelector() {
                   className={`py-1 px-2 border-l border-t border-r border-gray-300 bg-gray-200 text-sm cursor-pointer ${
                     selectedTab === "editor" ? "bg-white" : ""
                   }`}
-                  onClick={() => {
-                    setEditorSongId(null);
-                    setSelectedTab("editor");
-                  }}
+                  onClick={() => openEditor(null)}
                 >
                   Edytor pieśni
                 </button>
@@ -301,10 +309,7 @@ export default function DisplaySelector() {
                 selectedSchedule={selectedSchedule}
                 onSongAdded={handleSongAdded}
                 onPreview={openPreview}
-                onEditSong={(id) => {
-                  setEditorSongId(id);
-                  setSelectedTab("editor");
-                }}
+                onEditSong={(id) => openEditor(id)}
               />
             </div>
             <div className="flex-2 flex flex-col">

--- a/src/renderer/DisplaySelector.jsx
+++ b/src/renderer/DisplaySelector.jsx
@@ -12,6 +12,7 @@ import { Schedule } from "./components/Schedule";
 import { ScheduleList } from "./components/ScheduleList";
 import { SongList } from "./components/SongList";
 import { SongView } from "./components/SongView";
+import { SongEditor } from "./components/SongEditor";
 
 export default function DisplaySelector() {
   const [displays, setDisplays] = useState([]);
@@ -31,6 +32,7 @@ export default function DisplaySelector() {
   const [currentSong, setCurrentSong] = useState(null);
   const [previewSong, setPreviewSong] = useState(null);
   const [previewVerseIndex, setPreviewVerseIndex] = useState(0);
+  const [editorSongId, setEditorSongId] = useState(null);
 
   useEffect(() => {
     window.api.getDisplays().then(async (list) => {
@@ -249,95 +251,116 @@ export default function DisplaySelector() {
   return (
     <div className="flex flex-1 flex-col">
       <div className="flex-1 flex overflow-hidden">
-        <div className="flex-1 border-r border-gray-300">
-          <div className="border-b border-gray-300 flex pt-1 px-1 gap-1">
-            <button
-              className={`py-1 px-2 border-l border-t border-r border-gray-300 bg-gray-200 text-sm cursor-pointer ${
-                selectedTab === "categories" ? "bg-white" : ""
-              }`}
-              onClick={() => setSelectedTab("categories")}
-            >
-              Kategorie
-            </button>
-            <button
-              className={`py-1 px-2 border-l border-t border-r border-gray-300 bg-gray-200 text-sm cursor-pointer ${
-                selectedTab === "schedules" ? "bg-white" : ""
-              }`}
-              onClick={() => setSelectedTab("schedules")}
-            >
-              Harmonogramy
-            </button>
-            <button onClick={() => setSelectedTab("text")}>Notatki</button>
-          </div>
-          {selectedTab === "categories" ? (
-            <CategoryList setCategory={setCategory} />
-          ) : selectedTab === "schedules" ? (
-            <ScheduleList setSelectedSchedule={setSelectedSchedule} />
-          ) : null}
-          {selectedTab === "text" && <TextTab />}
-        </div>
-        <div className="flex-1 border-r border-gray-300 overflow-auto">
-          <SongList
-            category={category}
-            setSelectedSongId={setSelectedSongId}
-            selectedSchedule={selectedSchedule}
-            onSongAdded={handleSongAdded}
-            onPreview={openPreview}
-          />
-        </div>
-        <div className="flex-2 flex flex-col">
-          <div className="flex-1 bg-black text-white overflow-hidden p-4">
-            {previewSong ? (
-              <div className="h-full flex flex-col">
-                <div
-                  className="flex-1 overflow-auto"
-                  dangerouslySetInnerHTML={{
-                    __html: previewSong.verses[previewVerseIndex].text.replace(
-                      /\n/g,
-                      "<br />"
-                    ),
+        {selectedTab === "editor" ? (
+          <SongEditor songId={editorSongId} setSongId={setEditorSongId} />
+        ) : (
+          <>
+            <div className="flex-1 border-r border-gray-300">
+              <div className="border-b border-gray-300 flex pt-1 px-1 gap-1">
+                <button
+                  className={`py-1 px-2 border-l border-t border-r border-gray-300 bg-gray-200 text-sm cursor-pointer ${
+                    selectedTab === "categories" ? "bg-white" : ""
+                  }`}
+                  onClick={() => setSelectedTab("categories")}
+                >
+                  Kategorie
+                </button>
+                <button
+                  className={`py-1 px-2 border-l border-t border-r border-gray-300 bg-gray-200 text-sm cursor-pointer ${
+                    selectedTab === "schedules" ? "bg-white" : ""
+                  }`}
+                  onClick={() => setSelectedTab("schedules")}
+                >
+                  Harmonogramy
+                </button>
+                <button
+                  className={`py-1 px-2 border-l border-t border-r border-gray-300 bg-gray-200 text-sm cursor-pointer ${
+                    selectedTab === "editor" ? "bg-white" : ""
+                  }`}
+                  onClick={() => {
+                    setEditorSongId(null);
+                    setSelectedTab("editor");
                   }}
-                />
-                <div className="flex justify-center gap-2 mt-2">
-                  <button
-                    className="px-2 py-1 bg-gray-300 rounded hover:bg-gray-200 disabled:text-gray-400 disabled:hover:bg-gray-300"
-                    onClick={handlePreviewPrev}
-                    disabled={previewVerseIndex === 0}
-                  >
-                    <FaAngleLeft size={30} />
-                  </button>
-                  <button
-                    className="px-2 py-1 bg-gray-300 rounded hover:bg-gray-200 disabled:text-gray-400 disabled:hover:bg-gray-300"
-                    onClick={handlePreviewNext}
-                    disabled={
-                      previewVerseIndex === previewSong.verses.length - 1
-                    }
-                  >
-                    <FaAngleRight size={30} />
-                  </button>
-                </div>
+                >
+                  Edytor pieśni
+                </button>
+                <button onClick={() => setSelectedTab("text")}>Notatki</button>
               </div>
-            ) : windowOpened ? (
-              <div
-                className="w-full h-full overflow-auto"
-                dangerouslySetInnerHTML={{
-                  __html: currentText.replace(/\n/g, "<br />"),
+              {selectedTab === "categories" ? (
+                <CategoryList setCategory={setCategory} />
+              ) : selectedTab === "schedules" ? (
+                <ScheduleList setSelectedSchedule={setSelectedSchedule} />
+              ) : selectedTab === "text" ? (
+                <TextTab />
+              ) : null}
+            </div>
+            <div className="flex-1 border-r border-gray-300 overflow-auto">
+              <SongList
+                category={category}
+                setSelectedSongId={setSelectedSongId}
+                selectedSchedule={selectedSchedule}
+                onSongAdded={handleSongAdded}
+                onPreview={openPreview}
+                onEditSong={(id) => {
+                  setEditorSongId(id);
+                  setSelectedTab("editor");
                 }}
               />
-            ) : (
-              <SongView song={song} />
-            )}
-          </div>
-          <div className="flex-1 flex">
-            <Schedule
-              selectedSchedule={selectedSchedule}
-              scheduleSongs={scheduleSongs}
-              setScheduleSongs={setScheduleSongs}
-              currentSongId={scheduleSongs[currentSongIndex]?.song_id}
-              onPreviewSong={openPreview}
-            />
-          </div>
-        </div>
+            </div>
+            <div className="flex-2 flex flex-col">
+              <div className="flex-1 bg-black text-white overflow-hidden p-4">
+                {previewSong ? (
+                  <div className="h-full flex flex-col">
+                    <div
+                      className="flex-1 overflow-auto"
+                      dangerouslySetInnerHTML={{
+                        __html: previewSong.verses[
+                          previewVerseIndex
+                        ].text.replace(/\n/g, "<br />"),
+                      }}
+                    />
+                    <div className="flex justify-center gap-2 mt-2">
+                      <button
+                        className="px-2 py-1 bg-gray-300 rounded hover:bg-gray-200 disabled:text-gray-400 disabled:hover:bg-gray-300"
+                        onClick={handlePreviewPrev}
+                        disabled={previewVerseIndex === 0}
+                      >
+                        <FaAngleLeft size={30} />
+                      </button>
+                      <button
+                        className="px-2 py-1 bg-gray-300 rounded hover:bg-gray-200 disabled:text-gray-400 disabled:hover:bg-gray-300"
+                        onClick={handlePreviewNext}
+                        disabled={
+                          previewVerseIndex === previewSong.verses.length - 1
+                        }
+                      >
+                        <FaAngleRight size={30} />
+                      </button>
+                    </div>
+                  </div>
+                ) : windowOpened ? (
+                  <div
+                    className="w-full h-full overflow-auto"
+                    dangerouslySetInnerHTML={{
+                      __html: currentText.replace(/\n/g, "<br />"),
+                    }}
+                  />
+                ) : (
+                  <SongView song={song} />
+                )}
+              </div>
+              <div className="flex-1 flex">
+                <Schedule
+                  selectedSchedule={selectedSchedule}
+                  scheduleSongs={scheduleSongs}
+                  setScheduleSongs={setScheduleSongs}
+                  currentSongId={scheduleSongs[currentSongIndex]?.song_id}
+                  onPreviewSong={openPreview}
+                />
+              </div>
+            </div>
+          </>
+        )}
       </div>
       <div className="border-t border-gray-300 p-2 flex justify-end gap-3">
         {windowOpened ? (

--- a/src/renderer/components/SongEditor.jsx
+++ b/src/renderer/components/SongEditor.jsx
@@ -6,6 +6,7 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
   const [categories, setCategories] = useState([]);
   const [verses, setVerses] = useState([{ text: "" }]);
   const [current, setCurrent] = useState(0);
+  const [saved, setSaved] = useState(false);
 
   useEffect(() => {
     window.api.getCategories().then(setCategories);
@@ -43,6 +44,17 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
     });
   };
 
+  const removeVerse = (index) => {
+    if (!window.confirm("Usunąć tę zwrotkę?")) return;
+    setVerses((prev) => {
+      const arr = prev.filter((_, i) => i !== index);
+      if (!arr.length) arr.push({ text: "" });
+      const newCurrent = Math.min(current, arr.length - 1);
+      setCurrent(newCurrent);
+      return arr;
+    });
+  };
+
   const handleSave = async () => {
     const payload = {
       id: songId,
@@ -52,6 +64,8 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
     };
     const res = await window.api.saveSong(payload);
     if (res?.id && setSongId) setSongId(res.id);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
   };
 
   return (
@@ -71,21 +85,32 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
               className="px-2 py-1 bg-gray-300 hover:bg-gray-200 rounded"
               onClick={addVerse}
             >
-              Dodaj slajd
+              Dodaj zwrotkę
             </button>
           </div>
           <div className="flex-1 overflow-auto">
             <ul>
               {verses.map((v, i) => (
                 <li key={i}>
-                  <button
-                    className={`w-full text-left px-3 py-1 border-b border-gray-300 cursor-pointer hover:bg-gray-100 ${
-                      current === i ? "bg-gray-200" : ""
-                    }`}
-                    onClick={() => setCurrent(i)}
-                  >
-                    Zwrotka {i + 1}
-                  </button>
+                  <div className="flex">
+                    <button
+                      className={`flex-1 text-left px-3 py-1 border-b border-gray-300 cursor-pointer hover:bg-gray-100 ${
+                        current === i ? "bg-gray-200" : ""
+                      }`}
+                      onClick={() => setCurrent(i)}
+                    >
+                      Zwrotka {i + 1}
+                    </button>
+                    <button
+                      className="px-2 text-red-600 border-b border-gray-300 hover:bg-gray-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        removeVerse(i);
+                      }}
+                    >
+                      ✕
+                    </button>
+                  </div>
                 </li>
               ))}
             </ul>
@@ -116,6 +141,7 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
             >
               Zapisz
             </button>
+            {saved && <span className="text-green-600">Zapisano</span>}
           </div>
           <textarea
             className="flex-1 p-2 overflow-auto"

--- a/src/renderer/components/SongEditor.jsx
+++ b/src/renderer/components/SongEditor.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export const SongEditor = ({ songId, setSongId }) => {
+  const [title, setTitle] = useState("");
+  const [category, setCategory] = useState("");
+  const [categories, setCategories] = useState([]);
+  const [verses, setVerses] = useState([{ text: "" }]);
+  const [current, setCurrent] = useState(0);
+  const editorRef = useRef(null);
+
+  useEffect(() => {
+    window.api.getCategories().then(setCategories);
+  }, []);
+
+  useEffect(() => {
+    if (songId) {
+      window.api.getSong(songId).then((data) => {
+        if (!data) return;
+        setTitle(data.title);
+        setCategory(data.category_code || "");
+        setVerses(data.verses.length ? data.verses : [{ text: "" }]);
+        setCurrent(0);
+      });
+    } else {
+      setTitle("");
+      setCategory(categories?.[0]?.code || "");
+      setVerses([{ text: "" }]);
+      setCurrent(0);
+    }
+  }, [songId, categories]);
+
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.innerHTML = verses[current]?.text || "";
+    }
+  }, [current, verses]);
+
+  const handleInput = () => {
+    const html = editorRef.current.innerHTML;
+    setVerses((prev) =>
+      prev.map((v, i) => (i === current ? { ...v, text: html } : v))
+    );
+  };
+
+  const addVerse = () => {
+    setVerses((prev) => {
+      const arr = [...prev, { text: "" }];
+      setCurrent(arr.length - 1);
+      return arr;
+    });
+  };
+
+  const handleSave = async () => {
+    const payload = {
+      id: songId,
+      title,
+      category_code: category,
+      verses,
+    };
+    const res = await window.api.saveSong(payload);
+    if (res?.id && setSongId) setSongId(res.id);
+  };
+
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      <div className="w-1/4 border-r border-gray-300 flex flex-col">
+        <div className="p-2 border-b border-gray-300">
+          <button
+            className="px-2 py-1 bg-gray-300 hover:bg-gray-200 rounded"
+            onClick={addVerse}
+          >
+            Dodaj slajd
+          </button>
+        </div>
+        <div className="flex-1 overflow-auto">
+          <ul>
+            {verses.map((v, i) => (
+              <li key={i}>
+                <button
+                  className={`w-full text-left px-3 py-1 border-b border-gray-300 cursor-pointer hover:bg-gray-100 ${
+                    current === i ? "bg-gray-200" : ""
+                  }`}
+                  onClick={() => setCurrent(i)}
+                >
+                  Zwrotka {i + 1}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <div className="flex-1 border-r border-gray-300 flex flex-col">
+        <div className="p-2 flex gap-2 items-center border-b border-gray-300">
+          <input
+            className="flex-1 border p-1"
+            placeholder="Tytuł"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <select
+            className="border p-1"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {categories.map((c) => (
+              <option key={c.code} value={c.code}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <button
+            className="px-2 py-1 bg-green-300 hover:bg-green-200 rounded"
+            onClick={handleSave}
+          >
+            Zapisz
+          </button>
+        </div>
+        <div
+          ref={editorRef}
+          className="flex-1 p-2 overflow-auto"
+          contentEditable
+          onInput={handleInput}
+        />
+      </div>
+      <div className="w-1/3 bg-black text-white p-4 overflow-auto">
+        <div
+          dangerouslySetInnerHTML={{
+            __html: verses[current]?.text || "",
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/SongEditor.jsx
+++ b/src/renderer/components/SongEditor.jsx
@@ -68,23 +68,54 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
     setTimeout(() => setSaved(false), 2000);
   };
 
+  const greenButtonStyle = {
+    cursor: "pointer",
+    backgroundColor: "#4CAF50",
+    color: "white",
+    border: "none",
+    borderRadius: 4,
+    padding: "4px 8px",
+  };
+
+  const grayButtonStyle = {
+    ...greenButtonStyle,
+    backgroundColor: "#ccc",
+    color: "#000",
+  };
+
+  const verseButtonStyle = (selected) => ({
+    flex: 1,
+    textAlign: "left",
+    padding: "4px 12px",
+    border: "none",
+    borderBottom: "1px solid #ccc",
+    cursor: "pointer",
+    backgroundColor: selected ? "#e5e5e5" : "transparent",
+  });
+
+  const deleteButtonStyle = {
+    padding: "0 8px",
+    border: "none",
+    borderBottom: "1px solid #ccc",
+    cursor: "pointer",
+    background: "transparent",
+    color: "#f44336",
+  };
+
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
-      <div className="p-2 border-b border-gray-300">
-        <button
-          className="px-2 py-1 bg-gray-300 hover:bg-gray-200 rounded"
-          onClick={() => onBack && onBack()}
-        >
-          Powrót
+      <div className="p-2" style={{ borderBottom: "1px solid #ccc" }}>
+        <button style={grayButtonStyle} onClick={() => onBack && onBack()}>
+          Wróć do listy pieśni
         </button>
       </div>
       <div className="flex flex-1 overflow-hidden">
-        <div className="w-1/4 border-r border-gray-300 flex flex-col">
-          <div className="p-2 border-b border-gray-300">
-            <button
-              className="px-2 py-1 bg-gray-300 hover:bg-gray-200 rounded"
-              onClick={addVerse}
-            >
+        <div
+          className="w-1/4 flex flex-col"
+          style={{ borderRight: "1px solid #ccc" }}
+        >
+          <div className="p-2" style={{ borderBottom: "1px solid #ccc" }}>
+            <button style={greenButtonStyle} onClick={addVerse}>
               Dodaj zwrotkę
             </button>
           </div>
@@ -94,15 +125,13 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
                 <li key={i}>
                   <div className="flex">
                     <button
-                      className={`flex-1 text-left px-3 py-1 border-b border-gray-300 cursor-pointer hover:bg-gray-100 ${
-                        current === i ? "bg-gray-200" : ""
-                      }`}
+                      style={verseButtonStyle(current === i)}
                       onClick={() => setCurrent(i)}
                     >
                       Zwrotka {i + 1}
                     </button>
                     <button
-                      className="px-2 text-red-600 border-b border-gray-300 hover:bg-gray-100"
+                      style={deleteButtonStyle}
                       onClick={(e) => {
                         e.stopPropagation();
                         removeVerse(i);
@@ -116,8 +145,14 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
             </ul>
           </div>
         </div>
-        <div className="flex-1 border-r border-gray-300 flex flex-col">
-          <div className="p-2 flex gap-2 items-center border-b border-gray-300">
+        <div
+          className="flex-1 flex flex-col"
+          style={{ borderRight: "1px solid #ccc" }}
+        >
+          <div
+            className="p-2 flex gap-2 items-center"
+            style={{ borderBottom: "1px solid #ccc" }}
+          >
             <input
               className="flex-1 border p-1"
               placeholder="Tytuł"
@@ -135,13 +170,10 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
                 </option>
               ))}
             </select>
-            <button
-              className="px-2 py-1 bg-green-300 hover:bg-green-200 rounded"
-              onClick={handleSave}
-            >
+            <button style={greenButtonStyle} onClick={handleSave}>
               Zapisz
             </button>
-            {saved && <span className="text-green-600">Zapisano</span>}
+            {saved && <span style={{ color: '#16a34a' }}>Zapisano</span>}
           </div>
           <textarea
             className="flex-1 p-2 overflow-auto"

--- a/src/renderer/components/SongEditor.jsx
+++ b/src/renderer/components/SongEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 export const SongEditor = ({ songId, setSongId, onBack }) => {
   const [title, setTitle] = useState("");
@@ -6,7 +6,6 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
   const [categories, setCategories] = useState([]);
   const [verses, setVerses] = useState([{ text: "" }]);
   const [current, setCurrent] = useState(0);
-  const editorRef = useRef(null);
 
   useEffect(() => {
     window.api.getCategories().then(setCategories);
@@ -29,16 +28,10 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
     }
   }, [songId, categories]);
 
-  useEffect(() => {
-    if (editorRef.current) {
-      editorRef.current.innerHTML = verses[current]?.text || "";
-    }
-  }, [current, verses]);
-
-  const handleInput = () => {
-    const html = editorRef.current.innerHTML;
+  const handleInput = (e) => {
+    const text = e.target.value;
     setVerses((prev) =>
-      prev.map((v, i) => (i === current ? { ...v, text: html } : v))
+      prev.map((v, i) => (i === current ? { ...v, text } : v))
     );
   };
 
@@ -124,17 +117,16 @@ export const SongEditor = ({ songId, setSongId, onBack }) => {
               Zapisz
             </button>
           </div>
-          <div
-            ref={editorRef}
+          <textarea
             className="flex-1 p-2 overflow-auto"
-            contentEditable
-            onInput={handleInput}
+            value={verses[current]?.text || ""}
+            onChange={handleInput}
           />
         </div>
         <div className="w-1/3 bg-black text-white p-4 overflow-auto">
           <div
             dangerouslySetInnerHTML={{
-              __html: verses[current]?.text || "",
+              __html: (verses[current]?.text || "").replace(/\n/g, "<br />"),
             }}
           />
         </div>

--- a/src/renderer/components/SongEditor.jsx
+++ b/src/renderer/components/SongEditor.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-export const SongEditor = ({ songId, setSongId }) => {
+export const SongEditor = ({ songId, setSongId, onBack }) => {
   const [title, setTitle] = useState("");
   const [category, setCategory] = useState("");
   const [categories, setCategories] = useState([]);
@@ -62,72 +62,82 @@ export const SongEditor = ({ songId, setSongId }) => {
   };
 
   return (
-    <div className="flex flex-1 overflow-hidden">
-      <div className="w-1/4 border-r border-gray-300 flex flex-col">
-        <div className="p-2 border-b border-gray-300">
-          <button
-            className="px-2 py-1 bg-gray-300 hover:bg-gray-200 rounded"
-            onClick={addVerse}
-          >
-            Dodaj slajd
-          </button>
-        </div>
-        <div className="flex-1 overflow-auto">
-          <ul>
-            {verses.map((v, i) => (
-              <li key={i}>
-                <button
-                  className={`w-full text-left px-3 py-1 border-b border-gray-300 cursor-pointer hover:bg-gray-100 ${
-                    current === i ? "bg-gray-200" : ""
-                  }`}
-                  onClick={() => setCurrent(i)}
-                >
-                  Zwrotka {i + 1}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
+    <div className="flex flex-col flex-1 overflow-hidden">
+      <div className="p-2 border-b border-gray-300">
+        <button
+          className="px-2 py-1 bg-gray-300 hover:bg-gray-200 rounded"
+          onClick={() => onBack && onBack()}
+        >
+          Powrót
+        </button>
       </div>
-      <div className="flex-1 border-r border-gray-300 flex flex-col">
-        <div className="p-2 flex gap-2 items-center border-b border-gray-300">
-          <input
-            className="flex-1 border p-1"
-            placeholder="Tytuł"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
+      <div className="flex flex-1 overflow-hidden">
+        <div className="w-1/4 border-r border-gray-300 flex flex-col">
+          <div className="p-2 border-b border-gray-300">
+            <button
+              className="px-2 py-1 bg-gray-300 hover:bg-gray-200 rounded"
+              onClick={addVerse}
+            >
+              Dodaj slajd
+            </button>
+          </div>
+          <div className="flex-1 overflow-auto">
+            <ul>
+              {verses.map((v, i) => (
+                <li key={i}>
+                  <button
+                    className={`w-full text-left px-3 py-1 border-b border-gray-300 cursor-pointer hover:bg-gray-100 ${
+                      current === i ? "bg-gray-200" : ""
+                    }`}
+                    onClick={() => setCurrent(i)}
+                  >
+                    Zwrotka {i + 1}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div className="flex-1 border-r border-gray-300 flex flex-col">
+          <div className="p-2 flex gap-2 items-center border-b border-gray-300">
+            <input
+              className="flex-1 border p-1"
+              placeholder="Tytuł"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <select
+              className="border p-1"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            >
+              {categories.map((c) => (
+                <option key={c.code} value={c.code}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <button
+              className="px-2 py-1 bg-green-300 hover:bg-green-200 rounded"
+              onClick={handleSave}
+            >
+              Zapisz
+            </button>
+          </div>
+          <div
+            ref={editorRef}
+            className="flex-1 p-2 overflow-auto"
+            contentEditable
+            onInput={handleInput}
           />
-          <select
-            className="border p-1"
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-          >
-            {categories.map((c) => (
-              <option key={c.code} value={c.code}>
-                {c.name}
-              </option>
-            ))}
-          </select>
-          <button
-            className="px-2 py-1 bg-green-300 hover:bg-green-200 rounded"
-            onClick={handleSave}
-          >
-            Zapisz
-          </button>
         </div>
-        <div
-          ref={editorRef}
-          className="flex-1 p-2 overflow-auto"
-          contentEditable
-          onInput={handleInput}
-        />
-      </div>
-      <div className="w-1/3 bg-black text-white p-4 overflow-auto">
-        <div
-          dangerouslySetInnerHTML={{
-            __html: verses[current]?.text || "",
-          }}
-        />
+        <div className="w-1/3 bg-black text-white p-4 overflow-auto">
+          <div
+            dangerouslySetInnerHTML={{
+              __html: verses[current]?.text || "",
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/SongList.jsx
+++ b/src/renderer/components/SongList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { FaChevronRight } from "react-icons/fa";
+import { FaChevronRight, FaPen } from "react-icons/fa";
 
 export const SongList = ({
   category,
@@ -7,6 +7,7 @@ export const SongList = ({
   selectedSchedule,
   onSongAdded,
   onPreview,
+  onEditSong,
 }) => {
   const [songs, setSongs] = useState([]);
 
@@ -20,14 +21,16 @@ export const SongList = ({
     <ul>
       {songs.map((s) => (
         <li key={s.id}>
-          <button
-            className="border-b border-gray-300 w-full py-1 px-3 cursor-pointer hover:bg-gray-100 transition-colors text-left flex"
-            onClick={() => {
-              setSelectedSongId(s.id);
-              if (onPreview) onPreview(s.id);
-            }}
-          >
-            <span className="flex-1">{s.title}</span>
+          <div className="border-b border-gray-300 flex">
+            <button
+              className="flex-1 py-1 px-3 text-left cursor-pointer hover:bg-gray-100 transition-colors"
+              onClick={() => {
+                setSelectedSongId(s.id);
+                if (onPreview) onPreview(s.id);
+              }}
+            >
+              {s.title}
+            </button>
             <button
               className="hover:bg-green-200 transition-colors h-6 w-6 flex justify-center items-center rounded cursor-pointer"
               onClick={async (e) => {
@@ -39,7 +42,16 @@ export const SongList = ({
             >
               <FaChevronRight size={14} />
             </button>
-          </button>
+            <button
+              className="hover:bg-blue-200 transition-colors h-6 w-6 flex justify-center items-center rounded cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (onEditSong) onEditSong(s.id);
+              }}
+            >
+              <FaPen size={14} />
+            </button>
+          </div>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- add song editor tab to create or edit songs
- support saving songs and verses via new IPC handlers
- allow editing songs from list with new edit icon

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68aed3067b00832aa203a14a43d3d5e8